### PR TITLE
Remove static method for awarding achievements

### DIFF
--- a/src/cheevos/Cheevos.cpp
+++ b/src/cheevos/Cheevos.cpp
@@ -9,6 +9,8 @@
 
 #include "Cheevos.h"
 
+#include "libretro/FrontendBridge.h"
+#include "libretro/libretro.h"
 #include "libretro/LibretroEnvironment.h"
 #include "libretro/MemoryMap.h"
 #include "rcheevos/rconsoles.h"
@@ -148,16 +150,11 @@ bool CCheevos::AwardAchievement(
                              game_hash.c_str()) >= 0;
 }
 
-void CCheevos::GetCheevo_URL_ID(void (*callback)(const char* achievement_url, unsigned cheevo_id))
-{
-  m_callback = callback;
-}
-
-void CCheevos::DeactivateTriggeredAchievement(unsigned cheevo_id)
+void CCheevos::DeactivateTriggeredAchievement(unsigned cheevoId)
 {
   rc_runtime_deactivate_achievement(&m_runtime, cheevo_id);
   char url[URL_SIZE];
-  if (AwardAchievement(url, URL_SIZE, cheevo_id, 0, m_hash.c_str()))
+  if (AwardAchievement(url, URL_SIZE, cheevoId, 0, m_hash.c_str()))
   {
     std::string achievement_url = url;
     m_callback(url, cheevo_id);

--- a/src/cheevos/Cheevos.h
+++ b/src/cheevos/Cheevos.h
@@ -49,7 +49,6 @@ public:
   void DeactivateTriggeredAchievement(unsigned cheevo_id);
   void TestCheevoStatusPerFrame();
   unsigned int Peek(unsigned int address, unsigned int numBytes);
-  void GetCheevo_URL_ID(void (*callback)(const char* achievement_url, unsigned cheevo_id));
 
 private:
   const uint8_t* FixupFind(unsigned address, CMemoryMap& mmap, int consolecheevos);
@@ -59,8 +58,6 @@ private:
 
   static unsigned int PeekInternal(unsigned address, unsigned num_bytes, void* ud);
   static void RuntimeEventHandler(const rc_runtime_event_t* runtime_event);
-
-  void (*m_callback)(const char* achievement_url, unsigned cheevo_id);
 
   int m_consoleID;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -545,13 +545,6 @@ GAME_ERROR CGameLibRetro::ActivateAchievement(unsigned cheevo_id, const char* me
   return GAME_ERROR_NO_ERROR;
 }
 
-GAME_ERROR CGameLibRetro::GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
-                                                            unsigned cheevo_id))
-{
-  CCheevos::Get().GetCheevo_URL_ID(Callback);
-  return GAME_ERROR_NO_ERROR;
-}
-
 GAME_ERROR CGameLibRetro::RCResetRuntime()
 {
   CCheevos::Get().ResetRuntime();

--- a/src/client.h
+++ b/src/client.h
@@ -89,8 +89,6 @@ public:
   GAME_ERROR RCGetRichPresenceEvaluation(std::string& evaluation, unsigned int consoleID) override;
   GAME_ERROR ActivateAchievement(unsigned cheevo_id, const char* memaddr) override;
   GAME_ERROR RCResetRuntime() override;
-  GAME_ERROR GetCheevo_URL_ID(void (*Callback)(const char* achievement_url,
-                                               unsigned cheevo_id)) override;
 
 private:
   GAME_ERROR AudioAvailable();

--- a/src/libretro/FrontendBridge.cpp
+++ b/src/libretro/FrontendBridge.cpp
@@ -270,6 +270,14 @@ float CFrontendBridge::SensorGetInput(unsigned port, unsigned id)
   return axisState;
 }
 
+void CFrontendBridge::AwardAchievement(const char* achievementUrl, unsigned cheevoId)
+{
+  if (!CLibretroEnvironment::Get().GetAddon())
+    return;
+
+  CLibretroEnvironment::Get().GetAddon()->AwardAchievement(achievementUrl, cheevoId);
+}
+
 bool CFrontendBridge::StartCamera(void)
 {
   return false; // Not implemented

--- a/src/libretro/FrontendBridge.h
+++ b/src/libretro/FrontendBridge.h
@@ -47,6 +47,7 @@ namespace LIBRETRO
     static void LedSetState(int led, int state);
     static bool SensorSetState(unsigned port, retro_sensor_action action, unsigned rate);
     static float SensorGetInput(unsigned port, unsigned id);
+    static void AwardAchievement(const char* achievementUrl, unsigned cheevoId);
     static bool StartCamera(void);
     static void StopCamera(void);
     static retro_time_t PerfGetTimeUsec(void);


### PR DESCRIPTION
This PR continues the work of https://github.com/Shardul555/xbmc/pull/1 to move a static method to award achievements from RetroPlayer to game.libretro.

This PR should be merged before merging https://github.com/kodi-game/game.libretro/pull/73